### PR TITLE
Fixed the implementation of `Comparable`

### DIFF
--- a/Sources/SemanticVersioning/SemanticVersion.swift
+++ b/Sources/SemanticVersioning/SemanticVersion.swift
@@ -36,24 +36,23 @@ public struct PreRelease {
 
 extension SemanticVersion: Comparable {
     public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
-        if lhs.major < rhs.major { // 1.0.0 < 2.0.0.
-            return true
+        if lhs.major != rhs.major {
+            return lhs.major < rhs.major // 1.0.0 < 2.0.0
         }
-        if lhs.major == rhs.major {
-            if lhs.preRelease != nil && rhs.preRelease == nil {
-                return true
-            }
-            if let lhsPreRelease = lhs.preRelease, let rhsPreRelease = rhs.preRelease {
-                return lhsPreRelease < rhsPreRelease
-            }
+        if lhs.minor != rhs.minor {
+            return lhs.minor < rhs.minor // 1.1.0 < 1.2.0
         }
-        if lhs.minor < rhs.minor { // 1.1.0 < 1.2.0
-            return true
+        if lhs.patch != rhs.patch {
+            return lhs.patch < rhs.patch // 1.0.0 < 1.0.1
         }
-        if lhs.patch < rhs.patch { // 1.0.0 < 1.0.1
-            return true
+        switch (lhs.preRelease, rhs.preRelease) {
+        case (nil, _):
+            return false // 1.0.0 > 1.0.0-alpha
+        case (_?, nil):
+            return true // 1.0.0-alpha < 1.0.0
+        case (let lhsPreRelease?, let rhsPreRelease?):
+            return lhsPreRelease < rhsPreRelease // 1.0.0-alpha < 1.0.0-alpha.1
         }
-        return false
     }
 }
 

--- a/Tests/SemanticVersioningTests/SemanticVersionTests.swift
+++ b/Tests/SemanticVersioningTests/SemanticVersionTests.swift
@@ -74,9 +74,15 @@ class SemanticVersionTests: XCTestCase {
             patch: 0
         )
         
-        XCTAssertFalse(v210 < v201)
-        XCTAssertFalse(v201 < v200)
-        XCTAssertFalse(v200 < v120)
+        XCTExpectFailure {
+            XCTAssertLessThan(v210, v201)
+        }
+        XCTExpectFailure {
+            XCTAssertLessThan(v201, v200)
+        }
+        XCTExpectFailure {
+            XCTAssertLessThan(v200, v120)
+        }
     }
     
     func testPreReleasedOrder() async throws {
@@ -87,9 +93,16 @@ class SemanticVersionTests: XCTestCase {
         XCTAssertGreaterThan(v100, v100Alpha)
         XCTAssertGreaterThan(v101Alpha, v100)
         XCTAssertGreaterThan(v101Alpha, v100Alpha)
-        XCTAssertFalse(v100 < v100Alpha)
-        XCTAssertFalse(v101Alpha < v100)
-        XCTAssertFalse(v101Alpha < v100Alpha)
+        
+        XCTExpectFailure {
+            XCTAssertLessThan(v100, v100Alpha)
+        }
+        XCTExpectFailure {
+            XCTAssertLessThan(v101Alpha, v100)
+        }
+        XCTExpectFailure {
+            XCTAssertLessThan(v101Alpha, v100Alpha)
+        }
     }
     
     func testAsciiPreReleasedOrder() async throws {

--- a/Tests/SemanticVersioningTests/SemanticVersionTests.swift
+++ b/Tests/SemanticVersioningTests/SemanticVersionTests.swift
@@ -24,6 +24,34 @@ class SemanticVersionTests: XCTestCase {
     }
     
     func testOrder() async throws {
+        //  1.0.0 < 2.0.0 < 2.1.0 < 2.1.1
+        let v100 = SemanticVersion(
+            major: 1,
+            minor: 0,
+            patch: 0
+        )
+        let v200 = SemanticVersion(
+            major: 2,
+            minor: 0,
+            patch: 0
+        )
+        let v210 = SemanticVersion(
+            major: 2,
+            minor: 1,
+            patch: 0
+        )
+        let v211 = SemanticVersion(
+            major: 2,
+            minor: 1,
+            patch: 1
+        )
+
+        XCTAssertGreaterThan(v211, v210)
+        XCTAssertGreaterThan(v210, v200)
+        XCTAssertGreaterThan(v200, v100)
+    }
+    
+    func testWrongOrder() async throws {
         //  1.2.0 < 2.0.0 < 2.0.1 < 2.1.0
         let v120 = SemanticVersion(
             major: 1,
@@ -45,10 +73,7 @@ class SemanticVersionTests: XCTestCase {
             minor: 1,
             patch: 0
         )
-
-        XCTAssertGreaterThan(v210, v201)
-        XCTAssertGreaterThan(v201, v200)
-        XCTAssertGreaterThan(v200, v120)
+        
         XCTAssertFalse(v210 < v201)
         XCTAssertFalse(v201 < v200)
         XCTAssertFalse(v200 < v120)

--- a/Tests/SemanticVersioningTests/SemanticVersionTests.swift
+++ b/Tests/SemanticVersioningTests/SemanticVersionTests.swift
@@ -24,10 +24,10 @@ class SemanticVersionTests: XCTestCase {
     }
     
     func testOrder() async throws {
-        //  1.0.0 < 2.0.0 < 2.1.0 < 2.1.1
-        let v100 = SemanticVersion(
+        //  1.2.0 < 2.0.0 < 2.0.1 < 2.1.0
+        let v120 = SemanticVersion(
             major: 1,
-            minor: 0,
+            minor: 2,
             patch: 0
         )
         let v200 = SemanticVersion(
@@ -35,26 +35,36 @@ class SemanticVersionTests: XCTestCase {
             minor: 0,
             patch: 0
         )
+        let v201 = SemanticVersion(
+            major: 2,
+            minor: 0,
+            patch: 1
+        )
         let v210 = SemanticVersion(
             major: 2,
             minor: 1,
             patch: 0
         )
-        let v211 = SemanticVersion(
-            major: 2,
-            minor: 1,
-            patch: 1
-        )
 
-        XCTAssertGreaterThan(v211, v210)
-        XCTAssertGreaterThan(v210, v200)
-        XCTAssertGreaterThan(v200, v100)
+        XCTAssertGreaterThan(v210, v201)
+        XCTAssertGreaterThan(v201, v200)
+        XCTAssertGreaterThan(v200, v120)
+        XCTAssertFalse(v210 < v201)
+        XCTAssertFalse(v201 < v200)
+        XCTAssertFalse(v200 < v120)
     }
     
     func testPreReleasedOrder() async throws {
+        // 1.0.0-alpha < 1.0.0 < 1.0.1-alpha
         let v100Alpha = SemanticVersion(major: 1, minor: 0, patch: 0, preRelease: "alpha")
         let v100 = SemanticVersion(major: 1, minor: 0, patch: 0)
+        let v101Alpha = SemanticVersion(major: 1, minor: 0, patch: 1, preRelease: "alpha")
         XCTAssertGreaterThan(v100, v100Alpha)
+        XCTAssertGreaterThan(v101Alpha, v100)
+        XCTAssertGreaterThan(v101Alpha, v100Alpha)
+        XCTAssertFalse(v100 < v100Alpha)
+        XCTAssertFalse(v101Alpha < v100)
+        XCTAssertFalse(v101Alpha < v100Alpha)
     }
     
     func testAsciiPreReleasedOrder() async throws {


### PR DESCRIPTION
Fixed the implementation of `<` operator in the following steps:

1. Add and modify tests that should pass but they don't e6d7cca
    <img width="1528" alt="スクリーンショット 2023-08-02 22 41 28" src="https://github.com/noppefoxwolf/SemanticVersioning/assets/23174349/c65115df-e6d2-4b76-926c-235875c52ed1">
2. Fix the implementation 10d7282
3. Make sure tests no longer fail.